### PR TITLE
chore: prepare release 0.0.2-canary.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog
+## 0.0.2-canary.0 (2024-06-05)
+
+### Fixes
+
+#### release process
+
+#### fix: improve release process

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-data-systems"
-version = "0.0.1"
+version = "0.0.2-canary.0"
 
 [workspace]
 members = ["crates/nats-stream"]


### PR DESCRIPTION
This PR was created by Knope. Merging it will create a new release

### Fixes

#### release process

#### fix: improve release process