### PR TITLE
chore: prepare release 0.0.2-canary.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+## 0.0.2-canary.0 (2024-06-05)
+
+### Fixes
+
+- release porra

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "fuel-nats-stream"
-version = "0.0.1"
+version = "0.0.2-canary.0"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"
 repository = "https://github.com/FuelLabs/data-systems"
-version = "0.0.1"
+version = "0.0.2-canary.0"
 
 [workspace.dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
This PR was created by Knope. Merging it will create a new release